### PR TITLE
Create deno.yml

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -1,0 +1,42 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+# This workflow will install Deno then run `deno lint` and `deno test`.
+# For more information see: https://github.com/denoland/setup-deno
+
+name: Deno
+
+on:
+  push:
+    branches: ["develop"]
+  pull_request:
+    branches: ["develop"]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Setup repo
+        uses: actions/checkout@v3
+
+      - name: Setup Deno
+        # uses: denoland/setup-deno@v1
+        uses: denoland/setup-deno@61fe2df320078202e33d7d5ad347e7dcfa0e8f31  # v1.1.2
+        with:
+          deno-version: v1.x
+
+      # Uncomment this step to verify the use of 'deno fmt' on each commit.
+      # - name: Verify formatting
+      #   run: deno fmt --check
+
+      - name: Run linter
+        run: deno lint
+
+      - name: Run tests
+        run: deno test -A


### PR DESCRIPTION
- name: Setup Java JDK uses: actions/setup-java@v3.12.0 with: # The Java version to set up. Takes a whole or semver Java version. See examples of supported syntax in README file java-version: # optional # The path to the `.java-version` file. See examples of supported syntax in README file java-version-file: # optional # Java distribution. See the list of supported distributions in README file distribution:  # The package type (jdk, jre, jdk+fx, jre+fx) java-package: # optional, default is jdk # The architecture of the package (defaults to the action runner's architecture) architecture: # optional # Path to where the compressed JDK is located jdkFile: # optional # Set this option if you want the action to check for the latest available version that satisfies the version spec check-latest: # optional # ID of the distributionManagement repository in the pom.xml file. Default is `github` server-id: # optional, default is github # Environment variable name for the username for authentication to the Apache Maven repository. Default is $GITHUB_ACTOR server-username: # optional, default is GITHUB_ACTOR # Environment variable name for password or token for authentication to the Apache Maven repository. Default is $GITHUB_TOKEN server-password: # optional, default is GITHUB_TOKEN # Path to where the settings.xml file will be written. Default is ~/.m2. settings-path: # optional # Overwrite the settings.xml file if it exists. Default is "true". overwrite-settings: # optional, default is true # GPG private key to import. Default is empty string. gpg-private-key: # optional # Environment variable name for the GPG private key passphrase. Default is $GPG_PASSPHRASE. gpg-passphrase: # optional # Name of the build platform to cache dependencies. It can be "maven", "gradle" or "sbt". cache: # optional # Workaround to pass job status to post job step. This variable is not intended for manual setting job-status: # optional, default is ${{ job.status }} # The token used to authenticate when fetching version manifests hosted on github.com, such as for the Microsoft Build of OpenJDK. When running this action on github.com, the default value is sufficient. When running on GHES, you can pass a personal access token for github.com if you are experiencing rate limiting. token: # optional, default is ${{ github.server_url == 'https://github.com' && github.token || '' }} # Name of Maven Toolchain ID if the default name of "${distribution}_${java-version}" is not wanted. See examples of supported syntax in Advanced Usage file mvn-toolchain-id: # optional # Name of Maven Toolchain Vendor if the default name of "${distribution}" is not wanted. See examples of supported syntax in Advanced Usage file mvn-toolchain-vendor: # optional

## Ganache

Thank you for contributing! Take a moment to review our [**contributing guidelines**](https://github.com/trufflesuite/ganache-ui/blob/master/.github/CONTRIBUTING.md)
to make the process easy and effective for everyone involved.

**You must open an issue** before embarking on any significant pull request, especially those that
add a new library or change existing tests, otherwise you risk spending a lot of time working
on something that might not end up being merged into the project.

Before opening a pull request, please ensure:

- [x] You have followed our [**contributing guidelines**](https://github.com/trufflesuite/ganache-ui/blob/master/.github/CONTRIBUTING.md)
- [x] Pull request has tests
- [x] Code is well-commented, linted and follows project conventions
- [x] Documentation is updated (if necessary)
- [x] Description explains the issue/use-case resolved and auto-closes related issues

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)

**IMPORTANT**: By submitting a patch via a Pull Request, you agree to allow the project
owners to license your work under the terms of the [MIT License](https://github.com/trufflesuite/ganache-ui/blob/master/LICENSE.md).
